### PR TITLE
Update/admin enpoints

### DIFF
--- a/app/Http/Controllers/API/BookController.php
+++ b/app/Http/Controllers/API/BookController.php
@@ -60,7 +60,7 @@ class BookController extends Controller
         ], 201);
     }
 
-    // PUT /api/books/update/{isbn} USER
+    // PUT /api/books/isbn/{isbn} USER
     public function updateBook(Request $request, $isbn)
     {
         $book = Book::findOrFail($isbn);
@@ -81,7 +81,7 @@ class BookController extends Controller
         ],200);
     }
 
-    // DELETE /api/books/delete/{isbn} ADMIN
+    // DELETE /api/books/isbn/{isbn} ADMIN
     public function deleteBook($isbn)
     {
         $book = Book::find($isbn);

--- a/app/Http/Controllers/API/BookController.php
+++ b/app/Http/Controllers/API/BookController.php
@@ -81,7 +81,7 @@ class BookController extends Controller
         ],200);
     }
 
-    // DELETE /api/books/delete/{isbn} USER
+    // DELETE /api/books/delete/{isbn} ADMIN
     public function deleteBook($isbn)
     {
         $book = Book::find($isbn);

--- a/app/Http/Controllers/API/CommentController.php
+++ b/app/Http/Controllers/API/CommentController.php
@@ -18,6 +18,44 @@ class CommentController extends Controller
         ], 200);
     }
 
+    // DELETE /api/comments/id/{id}   ADMIN
+    public function destroyById($id)
+    {
+        $comment = Comment::find($id);
+
+        if (!$comment) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Commentaire non trouvé',
+            ], 404);
+        }
+
+        $comment->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Commentaire supprimé',
+            'data' => $comment,
+        ], 200);
+    }
+    // PUT /api/comments/id/{id}   ADMIN
+    public function updateById(Request $request, $id)
+    {
+        $comment = Comment::findOrFail($id);
+
+        $validated = $request->validate([
+            'comment_content' => 'required|string',
+        ]);
+
+        $comment->update($validated);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Commentaire mis à jour',
+            'data' => $comment,
+        ]);
+    }
+
     // GET /api/comments/isbn/{isbn}  USER
     public function getByIsbnForCurrentUser(Request $request, $isbn)
     {

--- a/app/Http/Controllers/API/FavoriteController.php
+++ b/app/Http/Controllers/API/FavoriteController.php
@@ -34,6 +34,28 @@ class FavoriteController extends Controller
         ], 200);
     }
 
+    // DELETE /api/favorites/id/{id}   ADMIN
+    public function destroyById($id)
+    {
+        $favorite = Favorite::find($id);
+
+        if (!$favorite) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Favori non trouvé',
+            ], 404);
+        }
+
+        $favorite->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Favori supprimé',
+            'data' => $favorite,
+        ], 200);
+    }
+
+
     // GET /api/favorites   USER
     public function getFavorites(Request $request)
     {

--- a/app/Http/Controllers/API/NoteController.php
+++ b/app/Http/Controllers/API/NoteController.php
@@ -18,6 +18,44 @@ class NoteController extends Controller
         ], 200);
     }
 
+    // DELETE /api/notes/id/{id}   (ADMIN)
+    public function destroyById($id)
+    {
+        $note = Note::find($id);
+
+        if (!$note) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Note non trouvée',
+            ], 404);
+        }
+
+        $note->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Note supprimée',
+            'data' => $note,
+        ], 200);
+    }
+    // PUT /api/notes/id/{id}   (ADMIN)
+    public function updateById(Request $request, $id)
+    {
+        $note = Note::findOrFail($id);
+
+        $validated = $request->validate([
+            'note_content' => 'required|string',
+        ]);
+
+        $note->update($validated);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Note mise à jour',
+            'data' => $note,
+        ], 200);
+    }
+
     // GET /api/notes/note/{note}   (USER)
     public function getBooksByUserAndNote(Request $request, $note)
     {

--- a/app/Http/Controllers/API/ReadingController.php
+++ b/app/Http/Controllers/API/ReadingController.php
@@ -19,6 +19,44 @@ class ReadingController extends Controller
         ], 200);
     }
 
+    // DELETE /api/reading/id/{id}   (ADMIN)
+    public function destroyById($id)
+    {
+        $reading = Reading::find($id);
+
+        if (!$reading) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Lecture non trouvée',
+            ], 404);
+        }
+
+        $reading->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Lecture supprimée',
+            'data' => $reading,
+        ], 200);
+    }
+    // PUT /api/reading/id/{id}   (ADMIN)
+    public function updateById(Request $request, $id)
+    {
+        $reading = Reading::findOrFail($id);
+
+        $validated = $request->validate([
+            'reading_content' => 'required|string',
+        ]);
+
+        $reading->update($validated);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Lecture mise à jour',
+            'data' => $reading,
+        ], 200);
+    }
+
     // GET /api/reading/notStarted   (USER)
     public function getNotStarted(Request $request)
 {

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -88,7 +88,7 @@ class UserController extends Controller
         ],200);
     }
 
-    // PUT /api/users/update/{id}
+    // PUT /api/users/update/{id}   ADMIN
     public function update(Request $request, $id)
     {
         $user = User::findOrFail($id);
@@ -107,7 +107,7 @@ class UserController extends Controller
         ],200);
     }
 
-    // DELETE /api/users/delete/{id}
+    // DELETE /api/users/delete/{id}    ADMIN
     public function destroy($id)
     {
         $user = User::findOrFail($id);

--- a/app/Http/Controllers/API/UserlistBookController.php
+++ b/app/Http/Controllers/API/UserlistBookController.php
@@ -39,6 +39,57 @@ class UserlistBookController extends Controller
         ], 200);
     }
 
+    // DELETE /api/userlistBooks/id/{id}   (ADMIN)
+    public function destroyById($id)
+    {
+        $deleted = DB::table('userlist_book')->where('id', $id)->delete();
+
+        if (!$deleted) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Entrée non trouvée',
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Entrée supprimée',
+        ], 200);
+    }
+    // PUT /api/userlistBooks/id/{id}   (ADMIN)
+    public function updateById(Request $request, $id)
+    {
+        $validated = $request->validate([
+            'userlist_id' => 'required|exists:userlists,userlist_id',
+            'isbn' => 'required|exists:books,isbn',
+        ]);
+
+        $updated = DB::table('userlist_book')
+            ->where('id', $id)
+            ->update([
+                'userlist_id' => $validated['userlist_id'],
+                'isbn' => $validated['isbn'],
+                'updated_at' => now(),
+            ]);
+
+        if (!$updated) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Entrée non trouvée ou non mise à jour',
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Entrée mise à jour',
+            'data' => [
+                'id' => $id,
+                'userlist_id' => $validated['userlist_id'],
+                'isbn' => $validated['isbn'],
+            ]
+        ], 200);
+    }
+
     // POST /api/userlistBooks   (USER)
     public function store(Request $request)
     {

--- a/app/Http/Controllers/API/UserlistController.php
+++ b/app/Http/Controllers/API/UserlistController.php
@@ -18,6 +18,47 @@ class UserlistController extends Controller
         ], 200);
     }
 
+    // DELETE /api/userlists/id/{id}   (ADMIN)
+    public function destroyById($id)
+    {
+        $userlist = Userlist::find($id);
+
+        if (!$userlist) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Liste non trouvée',
+            ], 404);
+        }
+
+        $userlist->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Liste supprimée',
+            'data' => $userlist,
+        ], 200);
+    }
+
+    // PUT /api/userlists/id/{id}   (ADMIN)
+    public function updateById(Request $request, $id)
+    {
+        $userlist = Userlist::findOrFail($id);
+
+        $validated = $request->validate([
+            'userlist_name' => 'required|string|max:255',
+            'userlist_description' => 'nullable|string',
+            'userlist_type' => 'required|string',
+        ]);
+
+        $userlist->update($validated);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Liste mise à jour',
+            'data' => $userlist,
+        ]);
+    }
+
     // GET /api/userlists   (USER)
     public function getUserLists(Request $request)
     {

--- a/app/Http/Controllers/API/WishlistController.php
+++ b/app/Http/Controllers/API/WishlistController.php
@@ -34,6 +34,45 @@ class WishlistController extends Controller
         ], 200);
     }
 
+    // DELETE /api/wishlists/id/{id}   ADMIN
+    public function destroyById($id)
+    {
+        $wishlist = Wishlist::find($id);
+
+        if (!$wishlist) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Wishlist non trouvée',
+            ], 404);
+        }
+
+        $wishlist->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Wishlist supprimée',
+            'data' => $wishlist,
+        ], 200);
+    }
+
+    // PUT /api/wishlists/id/{id}   ADMIN
+    public function updateById(Request $request, $id)
+    {
+        $wishlist = Wishlist::findOrFail($id);
+
+        $validated = $request->validate([
+            'isbn' => 'required|string|exists:books,isbn',
+        ]);
+
+        $wishlist->update($validated);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Wishlist mise à jour',
+            'data' => $wishlist,
+        ], 200);
+    }
+
     // GET /api/wishlists   USER
     public function getWishlists(Request $request)
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -84,25 +84,36 @@ Route::middleware('auth:sanctum')->group(function () {
 
         // Gestion des livres (accessibles uniquement aux admins)
         Route::get('/books/all', [BookController::class, 'getAllBooks']);
+        Route::delete('/books/isbn/{isbn}', [BookController::class, 'deleteBook']);
 
         // Gestion des commentaires (accessibles uniquement aux admins)
         Route::get('/comments/all', [CommentController::class, 'index']);
         Route::get('/comments/content/{content}', [CommentController::class, 'getByContent']);
+        Route::put('/comments/{id}', [CommentController::class, 'update']);
+        Route::delete('/comments/{id}', [CommentController::class, 'destroy']);
 
         // Gestion des favoris (accessibles uniquement aux admins)
         Route::get('/favorites/all', [FavoriteController::class, 'getBooksWithUsersWhoFavorited']);
+        Route::delete('/favorites/id/{id}', [FavoriteController::class, 'destroy']);
 
         // Gestion des wishlists (accessibles uniquement aux admins)
         Route::get('/wishlists/all', [WishlistController::class, 'getBooksWithUsersWhoWished']);
+        Route::delete('/wishlists/id/{id}', [WishlistController::class, 'destroy']);
+        Route::put('/wishlists/id/{id}', [WishlistController::class, 'updateById']);
 
         // Gestion des userlists (accessibles uniquement aux admins)
         Route::get('/userlists/all', [UserlistController::class, 'index']);
+        Route::put('/userlists/id/{id}', [UserlistController::class, 'updateById']);
+        Route::delete('/userlists/id/{id}', [UserlistController::class, 'destroyById']);
 
         // Gestion des livres dans les userlists (accessibles uniquement aux admins)
         Route::get('/userlistBooks/all', [UserlistBookController::class, 'index']);
+        Route::delete('/userlistBooks/id/{id}', [UserlistBookController::class, 'destroyById']);
+        Route::put('/userlistBooks/id/{id}', [UserlistBookController::class, 'updateById']);
 
         // Gestion des notes (accessibles uniquement aux admins)
         Route::get('/notes/all', [NoteController::class, 'index']);
+        Route::delete('/notes/id/{id}', [NoteController::class, 'destroy']);
 
     });
 });


### PR DESCRIPTION
This pull request introduces several updates to the API controllers and routes, primarily focused on adding new endpoints for administrative actions (e.g., updating and deleting resources) and refining existing routes for consistency. Below is a summary of the most important changes grouped by theme.

### Administrative Actions Added
* **Comment Management**: Added `destroyById` and `updateById` methods to allow admins to delete and update comments by ID in `CommentController`.
* **Favorite Management**: Added `destroyById` method to allow admins to delete favorites by ID in `FavoriteController`.
* **Note Management**: Added `destroyById` and `updateById` methods to allow admins to delete and update notes by ID in `NoteController`.
* **Reading Management**: Added `destroyById` and `updateById` methods to allow admins to delete and update readings by ID in `ReadingController`.
* **Userlist and Wishlist Management**: Added `destroyById` and `updateById` methods for both userlists and wishlists in their respective controllers. [[1]](diffhunk://#diff-c733051b008fa1c0c427e77053fca5595152c854956ae957991354db4cb0a140R21-R61) [[2]](diffhunk://#diff-54cfd99796994e7a7be54841a06e42d76a20f6b34b8bc1f91becfd949372f2e1R37-R75)

### Route Updates
* Updated `routes/api.php` to include new administrative endpoints for books, comments, favorites, wishlists, userlists, userlistBooks, and notes. These routes are now accessible only to admins.

### Endpoint Consistency
* Renamed book-related endpoints for consistency, e.g., changing `PUT /api/books/update/{isbn}` to `PUT /api/books/isbn/{isbn}` and `DELETE /api/books/delete/{isbn}` to `DELETE /api/books/isbn/{isbn}`. [[1]](diffhunk://#diff-7b821887077a0a118e63dcc21dd2bff908d0ac0da67616c7af5e4e6ae8140b94L63-R63) [[2]](diffhunk://#diff-7b821887077a0a118e63dcc21dd2bff908d0ac0da67616c7af5e4e6ae8140b94L84-R84)

### User Management Enhancements
* Marked `update` and `destroy` methods in `UserController` as admin-only by updating comments and routes. [[1]](diffhunk://#diff-778dbc211d4b2b766b752cf63e9ad35c7fae4f4bef8f279840fd45f2f1f945dbL91-R91) [[2]](diffhunk://#diff-778dbc211d4b2b766b752cf63e9ad35c7fae4f4bef8f279840fd45f2f1f945dbL110-R110)

### UserlistBook Management
* Added `destroyById` and `updateById` methods to `UserlistBookController` to allow admins to delete and update userlist-book relationships by ID.